### PR TITLE
Rethrow error if not ESM import error

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -59,8 +59,11 @@ exports.load = async function (id) {
 		let m = await Function('x', 'return import(x)')(href);
 		return m.default || m; // interop
 	} catch (e) {
-		// Check for `Uncaught SyntaxError: Unexpected token '('` for JS engines that don't support dynamic import
-		if (!(e instanceof SyntaxError)) throw e;
+		let ec = e && e.code;
+		// Rethrow error if error is not:
+		// - `Uncaught SyntaxError: Unexpected token '('` for JS engines that don't support dynamic import
+		// - a module resolution error
+		if (!(e instanceof SyntaxError || ec === 'ERR_MODULE_NOT_FOUND')) throw e;
 		return require(id);
 	}
 }

--- a/lib/util.js
+++ b/lib/util.js
@@ -64,7 +64,7 @@ exports.load = async function (id) {
 		// - `Uncaught SyntaxError: Unexpected token '('` for JS engines that don't support dynamic import
 		// - a module resolution error
 		if (e && e.message && !(
-			/^(Not supported|Unexpected token '\('|require\(\.\.\.\)\.pathToFileURL is not a function)/.test(e.message)
+			/^(Not supported|require\(\.\.\.\)\.pathToFileURL is not a function)/.test(e.message)
 			|| ec === 'ERR_MODULE_NOT_FOUND'
 		)) throw e;
 		return require(id);

--- a/lib/util.js
+++ b/lib/util.js
@@ -59,14 +59,12 @@ exports.load = async function (id) {
 		let m = await Function('x', 'return import(x)')(href);
 		return m.default || m; // interop
 	} catch (e) {
-		let ec = e && e.code;
-		// Rethrow error if error is not:
-		// - `Uncaught SyntaxError: Unexpected token '('` for JS engines that don't support dynamic import
-		// - a module resolution error
-		if (e && e.message && !(
-			/^(Not supported|require\(\.\.\.\)\.pathToFileURL is not a function)/.test(e.message)
-			|| ec === 'ERR_MODULE_NOT_FOUND'
-		)) throw e;
+		// Rethrow error if it is not any of:
+		// - not found error
+		// - old Node.js compatibility error
+		if (e && e.message && !e.code === 'ERR_MODULE_NOT_FOUND' &&
+			!['Not supported', 'require(...).pathToFileURL is not a function'].includes(e.message)
+		) throw e;
 		return require(id);
 	}
 }

--- a/lib/util.js
+++ b/lib/util.js
@@ -64,7 +64,7 @@ exports.load = async function (id) {
 		// - `Uncaught SyntaxError: Unexpected token '('` for JS engines that don't support dynamic import
 		// - a module resolution error
 		if (e && e.message && !(
-			/^(Not supported|Unexpected token '\('|require\(\.\.\.\)\.pathToFileURL is not a function/.test(e.message)
+			/^(Not supported|Unexpected token '\('|require\(\.\.\.\)\.pathToFileURL is not a function)/.test(e.message)
 			|| ec === 'ERR_MODULE_NOT_FOUND'
 		)) throw e;
 		return require(id);

--- a/lib/util.js
+++ b/lib/util.js
@@ -64,7 +64,7 @@ exports.load = async function (id) {
 		// - `Uncaught SyntaxError: Unexpected token '('` for JS engines that don't support dynamic import
 		// - a module resolution error
 		if (e && !(
-			/^(Error: Not supported|SyntaxError: Unexpected token '\('|Error: require\(\.\.\.\)\.pathToFileURL is not a function)/.test(String(e))
+			/^(Error: Not supported|SyntaxError: Unexpected token '\('|Uncaught TypeError: require\(\.\.\.\)\.pathToFileURL is not a function)/.test(String(e))
 			|| ec === 'ERR_MODULE_NOT_FOUND'
 		)) throw e;
 		return require(id);

--- a/lib/util.js
+++ b/lib/util.js
@@ -64,7 +64,7 @@ exports.load = async function (id) {
 		// - `Uncaught SyntaxError: Unexpected token '('` for JS engines that don't support dynamic import
 		// - a module resolution error
 		if (e && !(
-			/^(Not supported|SyntaxError: Unexpected token '\('|require\(\.\.\.\)\.pathToFileURL is not a function)/.test(String(e))
+			/^(Error: Not supported|SyntaxError: Unexpected token '\('|require\(\.\.\.\)\.pathToFileURL is not a function)/.test(String(e))
 			|| ec === 'ERR_MODULE_NOT_FOUND'
 		)) throw e;
 		return require(id);

--- a/lib/util.js
+++ b/lib/util.js
@@ -59,8 +59,8 @@ exports.load = async function (id) {
 		let m = await Function('x', 'return import(x)')(href);
 		return m.default || m; // interop
 	} catch (e) {
-		let ec = e && e.code;
-		if (ec !== 'ERR_MODULE_NOT_FOUND') throw e;
+		// Check for `Uncaught SyntaxError: Unexpected token '('` for JS engines that don't support dynamic import
+		if (!(e instanceof SyntaxError)) throw e;
 		return require(id);
 	}
 }

--- a/lib/util.js
+++ b/lib/util.js
@@ -63,7 +63,7 @@ exports.load = async function (id) {
 		// Rethrow error if error is not:
 		// - `Uncaught SyntaxError: Unexpected token '('` for JS engines that don't support dynamic import
 		// - a module resolution error
-		if (!(e instanceof SyntaxError || ec === 'ERR_MODULE_NOT_FOUND')) throw e;
+		if (e && !/^(SyntaxError: Unexpected token '\('|require\(\.\.\.\)\.pathToFileURL is not a function)/.test(String(e))) throw e;
 		return require(id);
 	}
 }

--- a/lib/util.js
+++ b/lib/util.js
@@ -60,7 +60,7 @@ exports.load = async function (id) {
 		return m.default || m; // interop
 	} catch (e) {
 		let ec = e && e.code;
-		if (ec !== 'ERR_REQUIRE_ESM') throw e;
+		if (ec !== 'ERR_MODULE_NOT_FOUND') throw e;
 		return require(id);
 	}
 }

--- a/lib/util.js
+++ b/lib/util.js
@@ -64,7 +64,7 @@ exports.load = async function (id) {
 		// - `Uncaught SyntaxError: Unexpected token '('` for JS engines that don't support dynamic import
 		// - a module resolution error
 		if (e && !(
-			/^(Error: Not supported|SyntaxError: Unexpected token '\('|require\(\.\.\.\)\.pathToFileURL is not a function)/.test(String(e))
+			/^(Error: Not supported|SyntaxError: Unexpected token '\('|Error: require\(\.\.\.\)\.pathToFileURL is not a function)/.test(String(e))
 			|| ec === 'ERR_MODULE_NOT_FOUND'
 		)) throw e;
 		return require(id);

--- a/lib/util.js
+++ b/lib/util.js
@@ -64,7 +64,7 @@ exports.load = async function (id) {
 		// - `Uncaught SyntaxError: Unexpected token '('` for JS engines that don't support dynamic import
 		// - a module resolution error
 		if (e && !(
-			/^(SyntaxError: Unexpected token '\('|require\(\.\.\.\)\.pathToFileURL is not a function)/.test(String(e))
+			/^(Not supported|SyntaxError: Unexpected token '\('|require\(\.\.\.\)\.pathToFileURL is not a function)/.test(String(e))
 			|| ec === 'ERR_MODULE_NOT_FOUND'
 		)) throw e;
 		return require(id);

--- a/lib/util.js
+++ b/lib/util.js
@@ -63,7 +63,10 @@ exports.load = async function (id) {
 		// Rethrow error if error is not:
 		// - `Uncaught SyntaxError: Unexpected token '('` for JS engines that don't support dynamic import
 		// - a module resolution error
-		if (e && !/^(SyntaxError: Unexpected token '\('|require\(\.\.\.\)\.pathToFileURL is not a function)/.test(String(e))) throw e;
+		if (e && !(
+			/^(SyntaxError: Unexpected token '\('|require\(\.\.\.\)\.pathToFileURL is not a function)/.test(String(e))
+			|| ec === 'ERR_MODULE_NOT_FOUND'
+		)) throw e;
 		return require(id);
 	}
 }

--- a/lib/util.js
+++ b/lib/util.js
@@ -59,6 +59,8 @@ exports.load = async function (id) {
 		let m = await Function('x', 'return import(x)')(href);
 		return m.default || m; // interop
 	} catch (e) {
+		let ec = e && e.code;
+		if (ec !== 'ERR_REQUIRE_ESM') throw e;
 		return require(id);
 	}
 }

--- a/lib/util.js
+++ b/lib/util.js
@@ -63,8 +63,9 @@ exports.load = async function (id) {
 		// Rethrow error if error is not:
 		// - `Uncaught SyntaxError: Unexpected token '('` for JS engines that don't support dynamic import
 		// - a module resolution error
-		if (e && !(
-			/^(Error: Not supported|SyntaxError: Unexpected token '\('|Uncaught TypeError: require\(\.\.\.\)\.pathToFileURL is not a function)/.test(String(e))
+		if (e && e.message && !(
+			/^require\(\.\.\.\)\.pathToFileURL is not a function/.test(e.message)
+			|| /^(Error: Not supported|SyntaxError: Unexpected token '\(')/.test(String(e))
 			|| ec === 'ERR_MODULE_NOT_FOUND'
 		)) throw e;
 		return require(id);

--- a/lib/util.js
+++ b/lib/util.js
@@ -64,8 +64,7 @@ exports.load = async function (id) {
 		// - `Uncaught SyntaxError: Unexpected token '('` for JS engines that don't support dynamic import
 		// - a module resolution error
 		if (e && e.message && !(
-			/^require\(\.\.\.\)\.pathToFileURL is not a function/.test(e.message)
-			|| /^(Error: Not supported|SyntaxError: Unexpected token '\(')/.test(String(e))
+			/^(Not supported|Unexpected token '\('|require\(\.\.\.\)\.pathToFileURL is not a function/.test(e.message)
 			|| ec === 'ERR_MODULE_NOT_FOUND'
 		)) throw e;
 		return require(id);


### PR DESCRIPTION
Copy of https://github.com/lukeed/ley/pull/36 for [`@upleveled/ley` package](https://www.npmjs.com/package/@upleveled/ley) until merged and published in mainline `ley`

---

Today when running `ley new` we received an error with `ERR_REQUIRE_ESM`:

- `ley.config.mjs` which had a JS error in it
- error swallowed by the `try/catch` in `load()` from `utils.js`
- `require()` ran on the `ley.config.mjs` file, which results in `ERR_REQUIRE_ESM` instead, which was confusing

This PR instead rethrows the error if it's not an error related to importing the ESM file (inspired by [similar code in `tsm`](https://github.com/lukeed/tsm/blob/833ed947f753602ee205fef99d959bb4a7321693/src/require.ts#L92-L93))