### PR TITLE
Switch new migrations to use ESM, TS and Postgres.js

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-13]
-        nodejs: [8, 10, 12, 14]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        nodejs: [22, 24]
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4

--- a/index.js
+++ b/index.js
@@ -102,19 +102,20 @@ exports.new = async function (opts={}) {
 	}
 
 	let filename = prefix + '-' + opts.filename.replace(/\s+/g, '-');
-	if (!/\.\w+$/.test(filename)) filename += opts.esm ? '.mjs' : '.js';
+	if (!/\.\w+$/.test(filename)) filename += '.ts';
 	let dir = resolve(opts.cwd || '.', opts.dir);
 	let file = join(dir, filename);
 
 	let str = '';
 	await mkdir(dir);
 
-	if (opts.esm) {
+	if ($.detect() === 'postgres') {
+		str += "import type { Sql } from 'postgres';\n\n";
+		str += 'export async function up(sql: Sql) {}\n\n';
+		str += 'export async function down(sql: Sql) {}\n';
+	} else {
 		str += 'export async function up(client) {\n\n}\n\n';
 		str += 'export async function down(client) {\n\n}\n';
-	} else {
-		str += 'exports.up = async client => {\n\n};\n\n';
-		str += 'exports.down = async client => {\n\n};\n';
 	}
 	writeFileSync(file, str);
 

--- a/index.js
+++ b/index.js
@@ -14,7 +14,8 @@ async function parse(opts) {
 	});
 
 	// cli(`--driver`) > config(exports.driver) > autodetect
-	let driver = opts.driver || opts.config.driver || $.detect();
+	let selected = opts.driver || (opts.config && opts.config.driver) || $.detect();
+	let driver = selected;
 	if (!driver) throw new Error('Unable to locate a database driver');
 
 	// allow `require` throws
@@ -27,7 +28,7 @@ async function parse(opts) {
 
 	const migrations = await $.glob(dir, opts.fileRegex);
 
-	return { driver, migrations };
+	return { driver, migrations, selected };
 }
 
 exports.up = async function (opts={}) {
@@ -86,7 +87,7 @@ exports.status = async function (opts={}) {
 }
 
 exports.new = async function (opts={}) {
-	let { migrations } = await parse(opts);
+	let { migrations, selected } = await parse(opts);
 
 	let prefix = '';
 	if (opts.timestamp) {
@@ -109,10 +110,14 @@ exports.new = async function (opts={}) {
 	let str = '';
 	await mkdir(dir);
 
-	if ($.detect() === 'postgres') {
+	let isTypeScript = /\.tsx?$/.test(filename);
+	if (selected === 'postgres' && isTypeScript) {
 		str += "import type { Sql } from 'postgres';\n\n";
 		str += 'export async function up(sql: Sql) {}\n\n';
 		str += 'export async function down(sql: Sql) {}\n';
+	} else if (selected === 'postgres') {
+		str += 'export async function up(sql) {\n\n}\n\n';
+		str += 'export async function down(sql) {\n\n}\n';
 	} else {
 		str += 'export async function up(client) {\n\n}\n\n';
 		str += 'export async function down(client) {\n\n}\n';

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const { join, resolve } = require('path');
+const { extname, join, resolve } = require('path');
 const { writeFileSync } = require('fs');
 const { mkdir } = require('mk-dirs');
 const $ = require('./lib/util');
@@ -90,8 +90,7 @@ exports.status = async function (opts={}) {
 }
 
 exports.new = async function (opts={}) {
-	let cwd = resolve(opts.cwd || '.');
-	let dir = join(cwd, opts.dir);
+	let dir = join(resolve(opts.cwd || '.'), opts.dir);
 	let migrations = await $.glob(dir, opts.fileRegex);
 
 	let prefix = '';
@@ -108,16 +107,19 @@ exports.new = async function (opts={}) {
 	}
 
 	let filename = prefix + '-' + opts.filename.replace(/\s+/g, '-');
-	if (!/\.\w+$/.test(filename)) filename += '.ts';
+	let ext = extname(filename);
+	if (!ext) {
+		filename += '.ts';
+	} else if (ext !== '.ts' && ext !== '.tsx') {
+		throw new Error('New migration files must use a TypeScript extension (.ts or .tsx)');
+	}
 	await mkdir(dir);
 
-	let driver = pickDriver(opts);
-	let withPostgresTypes = driver === 'postgres' && /\.tsx?$/.test(filename);
-	let arg = driver === 'postgres' ? (withPostgresTypes ? 'sql: Sql' : 'sql') : 'client';
-	let header = withPostgresTypes ? "import type { Sql } from 'postgres';\n\n" : '';
+	let isPostgres = pickDriver(opts) === 'postgres';
+	let arg = isPostgres ? 'sql: Sql' : 'client';
 	writeFileSync(
 		join(dir, filename),
-		`${header}export async function up(${arg}) {\n\n}\n\nexport async function down(${arg}) {\n\n}\n`
+		`${isPostgres ? "import type { Sql } from 'postgres';\n\n" : ''}export async function up(${arg}) {\n\n}\n\nexport async function down(${arg}) {\n\n}\n`
 	);
 
 	return filename;

--- a/index.js
+++ b/index.js
@@ -3,6 +3,10 @@ const { writeFileSync } = require('fs');
 const { mkdir } = require('mk-dirs');
 const $ = require('./lib/util');
 
+function pickDriver(opts) {
+	return opts.driver || (opts.config && opts.config.driver) || $.detect();
+}
+
 async function parse(opts) {
 	const cwd = resolve(opts.cwd || '.');
 	const dir = join(cwd, opts.dir);
@@ -14,8 +18,7 @@ async function parse(opts) {
 	});
 
 	// cli(`--driver`) > config(exports.driver) > autodetect
-	let selected = opts.driver || (opts.config && opts.config.driver) || $.detect();
-	let driver = selected;
+	let driver = pickDriver(opts);
 	if (!driver) throw new Error('Unable to locate a database driver');
 
 	// allow `require` throws
@@ -28,7 +31,7 @@ async function parse(opts) {
 
 	const migrations = await $.glob(dir, opts.fileRegex);
 
-	return { driver, migrations, selected };
+	return { driver, migrations };
 }
 
 exports.up = async function (opts={}) {
@@ -87,7 +90,9 @@ exports.status = async function (opts={}) {
 }
 
 exports.new = async function (opts={}) {
-	let { migrations, selected } = await parse(opts);
+	let cwd = resolve(opts.cwd || '.');
+	let dir = join(cwd, opts.dir);
+	let migrations = await $.glob(dir, opts.fileRegex);
 
 	let prefix = '';
 	if (opts.timestamp) {
@@ -104,25 +109,16 @@ exports.new = async function (opts={}) {
 
 	let filename = prefix + '-' + opts.filename.replace(/\s+/g, '-');
 	if (!/\.\w+$/.test(filename)) filename += '.ts';
-	let dir = resolve(opts.cwd || '.', opts.dir);
-	let file = join(dir, filename);
-
-	let str = '';
 	await mkdir(dir);
 
-	let isTypeScript = /\.tsx?$/.test(filename);
-	if (selected === 'postgres' && isTypeScript) {
-		str += "import type { Sql } from 'postgres';\n\n";
-		str += 'export async function up(sql: Sql) {}\n\n';
-		str += 'export async function down(sql: Sql) {}\n';
-	} else if (selected === 'postgres') {
-		str += 'export async function up(sql) {\n\n}\n\n';
-		str += 'export async function down(sql) {\n\n}\n';
-	} else {
-		str += 'export async function up(client) {\n\n}\n\n';
-		str += 'export async function down(client) {\n\n}\n';
-	}
-	writeFileSync(file, str);
+	let driver = pickDriver(opts);
+	let withPostgresTypes = driver === 'postgres' && /\.tsx?$/.test(filename);
+	let arg = driver === 'postgres' ? (withPostgresTypes ? 'sql: Sql' : 'sql') : 'client';
+	let header = withPostgresTypes ? "import type { Sql } from 'postgres';\n\n" : '';
+	writeFileSync(
+		join(dir, filename),
+		`${header}export async function up(${arg}) {\n\n}\n\nexport async function down(${arg}) {\n\n}\n`
+	);
 
 	return filename;
 }

--- a/index.js
+++ b/index.js
@@ -90,8 +90,7 @@ exports.status = async function (opts={}) {
 }
 
 exports.new = async function (opts={}) {
-	let dir = join(resolve(opts.cwd || '.'), opts.dir);
-	let migrations = await $.glob(dir, opts.fileRegex);
+	let { migrations } = await parse(opts);
 
 	let prefix = '';
 	if (opts.timestamp) {
@@ -113,12 +112,14 @@ exports.new = async function (opts={}) {
 	} else if (ext !== '.ts' && ext !== '.tsx') {
 		throw new Error('New migration files must use a TypeScript extension (.ts or .tsx)');
 	}
+	let dir = resolve(opts.cwd || '.', opts.dir);
+	let file = join(dir, filename);
 	await mkdir(dir);
 
 	let isPostgres = resolveDriver(opts) === 'postgres';
 	let arg = isPostgres ? 'sql: Sql' : 'client';
 	writeFileSync(
-		join(dir, filename),
+		file,
 		`${isPostgres ? "import type { Sql } from 'postgres';\n\n" : ''}export async function up(${arg}) {\n\n}\n\nexport async function down(${arg}) {\n\n}\n`
 	);
 

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const { writeFileSync } = require('fs');
 const { mkdir } = require('mk-dirs');
 const $ = require('./lib/util');
 
-function pickDriver(opts) {
+function resolveDriver(opts) {
 	return opts.driver || (opts.config && opts.config.driver) || $.detect();
 }
 
@@ -18,7 +18,7 @@ async function parse(opts) {
 	});
 
 	// cli(`--driver`) > config(exports.driver) > autodetect
-	let driver = pickDriver(opts);
+	let driver = resolveDriver(opts);
 	if (!driver) throw new Error('Unable to locate a database driver');
 
 	// allow `require` throws
@@ -115,7 +115,7 @@ exports.new = async function (opts={}) {
 	}
 	await mkdir(dir);
 
-	let isPostgres = pickDriver(opts) === 'postgres';
+	let isPostgres = resolveDriver(opts) === 'postgres';
 	let arg = isPostgres ? 'sql: Sql' : 'client';
 	writeFileSync(
 		join(dir, filename),

--- a/ley.d.ts
+++ b/ley.d.ts
@@ -22,7 +22,6 @@ declare namespace Options {
 		filename: string;
 		timestamp?: boolean;
 		length?: number;
-		esm?: boolean;
 	}
 }
 

--- a/readme.md
+++ b/readme.md
@@ -72,34 +72,34 @@ Because of this, it's often recommended to prefix migrations with a timestamp or
 
 ```
 /migrations
-  |-- 000-users.js
-  |-- 001-teams.js
-  |-- 002-seats.js
+  |-- 000-users.ts
+  |-- 001-teams.ts
+  |-- 002-seats.ts
 ```
 
-> **Note**: You may create the next file via `ley new todos --length 3` where `todos` is a meaningful name.<br>The above command will create the `migrations/003-todos.js` filepath.
+> **Note**: You may create the next file via `ley new todos --length 3` where `todos` is a meaningful name.<br>The above command will create the `migrations/003-todos.ts` filepath.
 
 ***Timestamped***
 
 ```
 /migrations
-  |-- 1581323445-users.js
-  |-- 1581323453-teams.js
-  |-- 1581323458-seats.js
+  |-- 1581323445-users.ts
+  |-- 1581323453-teams.ts
+  |-- 1581323458-seats.ts
 ```
 
-> **Note**: You may create the next file via `ley new todos --timestamp` where `todos` is a meaningful name.<br>The above command will create the `migrations/1584389617-todos.js` filepath...or similar.
+> **Note**: You may create the next file via `ley new todos --timestamp` where `todos` is a meaningful name.<br>The above command will create the `migrations/1584389617-todos.ts` filepath...or similar.
 
 
 **The order of your migrations is critically important!**<br>Migrations must be treated as an append-only immutable task chain. Without this, there's no way to _reliably_ rollback or recreate your database.
 
-> **Example:** (Above) You cannot apply/create `001-teams.js` _after_ `002-seats.js` has already been applied.<br>Doing so would force your teammates or database replicas to recreate "the world" in the wrong sequence.<br>This may not _always_ pose a problem (eg, unrelated tasks) but it **often does** and so `ley` enforces this practice.
+> **Example:** (Above) You cannot apply/create `001-teams.ts` _after_ `002-seats.ts` has already been applied.<br>Doing so would force your teammates or database replicas to recreate "the world" in the wrong sequence.<br>This may not _always_ pose a problem (eg, unrelated tasks) but it **often does** and so `ley` enforces this practice.
 
 Lastly, each migration file must have an `up` and a `down` task.<br>
 These must be exported functions &mdash; `async` okay! &mdash; and will receive your pre-installed client driver as its only argument:
 
 ```js
-exports.up = async function (DB) {
+export async function up(DB) {
   // with `pg` :: DB === pg.Client
   await DB.query(`select * from users`);
 
@@ -107,7 +107,7 @@ exports.up = async function (DB) {
   await DB`select * from users`;
 }
 
-exports.down = async function (DB) {
+export async function down(DB) {
   // My pre-configured "undo" function
 }
 ```
@@ -293,15 +293,9 @@ For extra confidence while writing your migration file(s), there are two options
 
 ### TypeScript
 
-1. Ensure [`tsm`](https://www.npmjs.com/package/tsm) is installed
+Node.js `v22.18.0+` enables TypeScript type stripping by default, so `.ts` migrations can run without `tsm` or other runtime transpilers.
 
-2. Run `ley` with the [`require`](#optsrequire) option so that `tsm` can process file(s)
-
-   ```sh
-   $ ley -r tsm <cmd>
-   # or
-   $ ley --require tsm <cmd>
-   ```
+> **Note:** This supports erasable TypeScript syntax. For TypeScript features that require transforms (eg, `enum`), use Node.js transform flags or a dedicated runtime.
 
 ### JSDoc
 
@@ -322,7 +316,7 @@ export async function up(DB) {
 ### ley.up(opts?)
 Returns: `Promise<string[]>`
 
-Returns a list of the _relative filenames_ (eg, `000-users.js`) that were successfully applied.
+Returns a list of the _relative filenames_ (eg, `000-users.ts`) that were successfully applied.
 
 #### opts.single
 Type: `boolean`<br>
@@ -336,7 +330,7 @@ By default, all migration files will be queue for application.
 ### ley.down(opts?)
 Returns: `Promise<string[]>`
 
-Returns a list of the _relative filenames_ (eg, `000-users.js`) that were successfully applied.
+Returns a list of the _relative filenames_ (eg, `000-users.ts`) that were successfully applied.
 
 #### opts.all
 Type: `boolean`<br>
@@ -349,13 +343,13 @@ By default, only the most recently-applied migration file is invoked.
 ### ley.status(opts?)
 Returns: `Promise<string[]>`
 
-Returns a list of the _relative filenames_ (eg, `000-users.js`) that have not yet been applied.
+Returns a list of the _relative filenames_ (eg, `000-users.ts`) that have not yet been applied.
 
 
 ### ley.new(opts?)
 Returns: `Promise<string>`
 
-Returns the newly created _relative filename_ (eg, `000-users.js`).
+Returns the newly created _relative filename_ (eg, `000-users.ts`).
 
 #### opts.filename
 Type: `string`
@@ -376,7 +370,7 @@ Type: `number`<br>
 Default: `5`
 
 When **not** using a timestamped prefix, this value controls the prefix total length.<br>
-For example, `00000-users.js` will be followed by `00001-teams.js`.
+For example, `00000-users.ts` will be followed by `00001-teams.ts`.
 
 
 ## Options

--- a/readme.md
+++ b/readme.md
@@ -356,7 +356,7 @@ Type: `string`
 
 **Required.** The name of the file to be created.
 
-> **Note:** A prefix will be prepended based on [`opts.timestamp`](#optstimestamp) and [`opts.length`](#optslength) values.<br>If your input does not already end with an extension, then `.ts` will be appended.
+> **Note:** A prefix will be prepended based on [`opts.timestamp`](#optstimestamp) and [`opts.length`](#optslength) values.<br>If your input does not already end with an extension, then `.ts` will be appended. If an extension is provided, it must be `.ts` or `.tsx`.
 
 #### opts.timestamp
 Type: `boolean`<br>

--- a/readme.md
+++ b/readme.md
@@ -223,11 +223,10 @@ export default {
 }
 ```
 
-Finally, migration files may also be written using ESM syntax:
+Migration files use ESM syntax:
 
 ```js
-// migrations/000-example.mjs
-// or w/ "type": "module" ~> migrations/000-example.js
+// migrations/000-example.js
 export async function up(DB) {
   // with `pg` :: DB === pg.Client
   await DB.query(`select * from users`);
@@ -241,18 +240,28 @@ export async function down(DB) {
 }
 ```
 
-You may generate new migration files in ESM syntax by passing the `--esm` flag to the `ley new` command:
+`ley new` generates ESM migrations by default:
 
 ```sh
-$ ley new todos --esm
-#=> migrations/003-todos.mjs
+$ ley new todos
+#=> migrations/003-todos.ts
 
-$ cat migrations/003-todos.mjs
+$ cat migrations/003-todos.ts
 #=> export async function up(client) {
 #=> }
 #=> 
 #=> export async function down(client) {
 #=> }
+```
+
+When `postgres` is auto-detected, generated migrations default to:
+
+```ts
+import type { Sql } from 'postgres';
+
+export async function up(sql: Sql) {}
+
+export async function down(sql: Sql) {}
 ```
 
 ## Drivers
@@ -300,7 +309,7 @@ You may also use [JSDoc](https://jsdoc.app/) annotations throughout your file to
 
 ```js
 /** @param {import('pg').Client} DB */
-exports.up = async function (DB) {
+export async function up(DB) {
   await DB.query(...)
 }
 ```
@@ -353,15 +362,7 @@ Type: `string`
 
 **Required.** The name of the file to be created.
 
-> **Note:** A prefix will be prepended based on [`opts.timestamp`](#optstimestamp) and [`opts.length`](#optslength) values.<br>If your input does not already end with an extension, then `.js` or `.mjs` will be appended.
-
-#### opts.esm
-Type: `boolean`<br>
-Default: `false`
-
-Create a migration file with ESM syntax.
-
-> **Note:** When true, the `opts.filename` will contain the `.mjs` file extension unless your input already has an extension.
+> **Note:** A prefix will be prepended based on [`opts.timestamp`](#optstimestamp) and [`opts.length`](#optslength) values.<br>If your input does not already end with an extension, then `.ts` will be appended.
 
 #### opts.timestamp
 Type: `boolean`<br>

--- a/readme.md
+++ b/readme.md
@@ -299,26 +299,11 @@ With any of these, if `driver` is a string then it will be passed through `requi
 > **Important:** All drivers must adhere to the [`Driver` interface](/ley.d.ts#L45-L67)!
 
 
-## Typed Migrations
+## TypeScript Support
 
-For extra confidence while writing your migration file(s), there are two options:
+`ley` uses Node.js v22.18.0+ TypeScript type stripping, so `.ts` migrations can run without additional runtime transpilers.
 
-### TypeScript
-
-Node.js `v22.18.0+` enables TypeScript type stripping by default, so `.ts` migrations can run without `tsm` or other runtime transpilers.
-
-> **Note:** This supports erasable TypeScript syntax. For TypeScript features that require transforms (eg, `enum`), use Node.js transform flags or a dedicated runtime.
-
-### JSDoc
-
-You may also use [JSDoc](https://jsdoc.app/) annotations throughout your file to achieve (most) of the benefits of TypeScript, but without installing and configuring TypeScript.
-
-```js
-/** @param {import('postgres').Sql} sql */
-export async function up(sql) {
-  await sql`select * from users`
-}
-```
+> **Note:** This supports erasable TypeScript syntax. For TypeScript features that require transforms (eg, `enum`), use Node.js transform flags such as `--experimental-transform-types`.
 
 ## API
 

--- a/readme.md
+++ b/readme.md
@@ -227,43 +227,6 @@ export default {
 }
 ```
 
-Migration files use ESM syntax:
-
-```ts
-// migrations/000-example.ts
-import type { Sql } from 'postgres';
-
-export async function up(sql: Sql) {
-  await sql`
-    create table if not exists users (
-      id serial primary key,
-      email text not null unique,
-      created_at timestamp with time zone default now()
-    );
-  `;
-}
-
-export async function down(sql: Sql) {
-  await sql`drop table if exists users`;
-}
-```
-
-`ley new` generates ESM migrations by default:
-
-```sh
-$ ley new todos
-#=> migrations/003-todos.ts
-
-$ cat migrations/003-todos.ts
-#=> import type { Sql } from 'postgres';
-#=> 
-#=> export async function up(sql: Sql) {
-#=> }
-#=> 
-#=> export async function down(sql: Sql) {
-#=> }
-```
-
 When `postgres` is auto-detected, generated migrations default to:
 
 ```ts

--- a/readme.md
+++ b/readme.md
@@ -99,15 +99,13 @@ Lastly, each migration file must have an `up` and a `down` task.<br>
 These must be exported functions &mdash; `async` okay! &mdash; and will receive your pre-installed client driver as its only argument:
 
 ```js
-export async function up(DB) {
-  // with `pg` :: DB === pg.Client
-  await DB.query(`select * from users`);
+import type { Sql } from 'postgres';
 
-  // with `postgres` :: DB === sql``
-  await DB`select * from users`;
+export async function up(sql: Sql) {
+  await sql`select * from users`;
 }
 
-export async function down(DB) {
+export async function down(sql: Sql) {
   // My pre-configured "undo" function
 }
 ```
@@ -225,17 +223,15 @@ export default {
 
 Migration files use ESM syntax:
 
-```js
-// migrations/000-example.js
-export async function up(DB) {
-  // with `pg` :: DB === pg.Client
-  await DB.query(`select * from users`);
+```ts
+// migrations/000-example.ts
+import type { Sql } from 'postgres';
 
-  // with `postgres` :: DB === sql``
-  await DB`select * from users`;
+export async function up(sql: Sql) {
+  await sql`select * from users`;
 }
 
-export async function down(DB) {
+export async function down(sql: Sql) {
   // My pre-configured "undo" function
 }
 ```
@@ -247,10 +243,12 @@ $ ley new todos
 #=> migrations/003-todos.ts
 
 $ cat migrations/003-todos.ts
-#=> export async function up(client) {
+#=> import type { Sql } from 'postgres';
+#=> 
+#=> export async function up(sql: Sql) {
 #=> }
 #=> 
-#=> export async function down(client) {
+#=> export async function down(sql: Sql) {
 #=> }
 ```
 
@@ -259,9 +257,11 @@ When `postgres` is auto-detected, generated migrations default to:
 ```ts
 import type { Sql } from 'postgres';
 
-export async function up(sql: Sql) {}
+export async function up(sql: Sql) {
+}
 
-export async function down(sql: Sql) {}
+export async function down(sql: Sql) {
+}
 ```
 
 ## Drivers
@@ -302,9 +302,9 @@ Node.js `v22.18.0+` enables TypeScript type stripping by default, so `.ts` migra
 You may also use [JSDoc](https://jsdoc.app/) annotations throughout your file to achieve (most) of the benefits of TypeScript, but without installing and configuring TypeScript.
 
 ```js
-/** @param {import('pg').Client} DB */
-export async function up(DB) {
-  await DB.query(...)
+/** @param {import('postgres').Sql} sql */
+export async function up(sql) {
+  await sql`select * from users`
 }
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -290,7 +290,7 @@ By default, all migration files will be queue for application.
 ### ley.down(opts?)
 Returns: `Promise<string[]>`
 
-Returns a list of the _relative filenames_ (eg, `000-users.ts`) whose `down` tasks were successfully executed (i.e., migrations that were rolled back).
+Returns a list of the _relative filenames_ (eg, `000-users.ts`) whose `down` tasks were successfully executed (migrations that were rolled back).
 
 #### opts.all
 Type: `boolean`<br>

--- a/readme.md
+++ b/readme.md
@@ -98,7 +98,7 @@ Because of this, it's often recommended to prefix migrations with a timestamp or
 Lastly, each migration file must have an `up` and a `down` task.<br>
 These must be exported functions &mdash; `async` okay! &mdash; and will receive your pre-installed client driver as its only argument:
 
-```js
+```ts
 import type { Sql } from 'postgres';
 
 export async function up(sql: Sql) {

--- a/readme.md
+++ b/readme.md
@@ -330,7 +330,7 @@ By default, all migration files will be queue for application.
 ### ley.down(opts?)
 Returns: `Promise<string[]>`
 
-Returns a list of the _relative filenames_ (eg, `000-users.ts`) that were successfully applied.
+Returns a list of the _relative filenames_ (eg, `000-users.ts`) whose `down` tasks were successfully executed (i.e., migrations that were rolled back).
 
 #### opts.all
 Type: `boolean`<br>

--- a/readme.md
+++ b/readme.md
@@ -102,11 +102,17 @@ These must be exported functions &mdash; `async` okay! &mdash; and will receive 
 import type { Sql } from 'postgres';
 
 export async function up(sql: Sql) {
-  await sql`select * from users`;
+  await sql`
+    create table if not exists users (
+      id serial primary key,
+      email text not null unique,
+      created_at timestamp with time zone default now()
+    );
+  `;
 }
 
 export async function down(sql: Sql) {
-  // My pre-configured "undo" function
+  await sql`drop table if exists users`;
 }
 ```
 
@@ -228,11 +234,17 @@ Migration files use ESM syntax:
 import type { Sql } from 'postgres';
 
 export async function up(sql: Sql) {
-  await sql`select * from users`;
+  await sql`
+    create table if not exists users (
+      id serial primary key,
+      email text not null unique,
+      created_at timestamp with time zone default now()
+    );
+  `;
 }
 
 export async function down(sql: Sql) {
-  // My pre-configured "undo" function
+  await sql`drop table if exists users`;
 }
 ```
 

--- a/test/index.js
+++ b/test/index.js
@@ -1,18 +1,8 @@
 const { test } = require('uvu');
 const assert = require('uvu/assert');
 const fs = require('fs');
-const os = require('os');
-const { join, parse, resolve } = require('path');
+const { join } = require('path');
 const ley = require('..');
-
-function tmpBaseDir() {
-	// Windows can place os.tmpdir() on a different drive than the checkout path.
-	// Use OS temp when roots match, otherwise keep temp files in test/ for safety.
-	if (process.platform !== 'win32') return os.tmpdir();
-	const cwdRoot = parse(resolve(process.cwd())).root.toLowerCase();
-	const tmpRoot = parse(resolve(os.tmpdir())).root.toLowerCase();
-	return cwdRoot === tmpRoot ? os.tmpdir() : __dirname;
-}
 
 test('exports', () => {
 	assert.type(ley, 'object');
@@ -22,25 +12,8 @@ test('exports', () => {
 	assert.type(ley.new, 'function');
 });
 
-test('new :: defaults to ESM .ts', async () => {
-	const cwd = fs.mkdtempSync(join(tmpBaseDir(), 'ley-new-default-'));
-	const migrations = join(cwd, 'migrations');
-	fs.mkdirSync(migrations);
-	fs.writeFileSync(join(migrations, '00001-first.js'), 'export async function up() {}\n');
-
-	try {
-		const output = await ley.new({ cwd, dir: 'migrations', filename: 'users', length: 5, driver: 'pg' });
-		assert.is(output, '00002-users.ts');
-
-		const body = fs.readFileSync(join(migrations, output), 'utf8');
-		assert.is(body, 'export async function up(client) {\n\n}\n\nexport async function down(client) {\n\n}\n');
-	} finally {
-		fs.rmSync(cwd, { recursive: true, force: true });
-	}
-});
-
 test('new :: postgres template uses Sql type', async () => {
-	const cwd = fs.mkdtempSync(join(tmpBaseDir(), 'ley-new-postgres-'));
+	const cwd = fs.mkdtempSync(join(__dirname, '.tmp-ley-new-postgres-'));
 	const migrations = join(cwd, 'migrations');
 	fs.mkdirSync(migrations);
 	fs.writeFileSync(join(migrations, '00001-first.js'), 'export async function up() {}\n');
@@ -52,7 +25,7 @@ test('new :: postgres template uses Sql type', async () => {
 		const body = fs.readFileSync(join(migrations, output), 'utf8');
 		assert.is(
 			body,
-			"import type { Sql } from 'postgres';\n\nexport async function up(sql: Sql) {}\n\nexport async function down(sql: Sql) {}\n"
+			"import type { Sql } from 'postgres';\n\nexport async function up(sql: Sql) {\n\n}\n\nexport async function down(sql: Sql) {\n\n}\n"
 		);
 	} finally {
 		fs.rmSync(cwd, { recursive: true, force: true });
@@ -60,7 +33,7 @@ test('new :: postgres template uses Sql type', async () => {
 });
 
 test('new :: postgres template is JS-compatible with .js extension', async () => {
-	const cwd = fs.mkdtempSync(join(tmpBaseDir(), 'ley-new-postgres-js-'));
+	const cwd = fs.mkdtempSync(join(__dirname, '.tmp-ley-new-postgres-js-'));
 	const migrations = join(cwd, 'migrations');
 	fs.mkdirSync(migrations);
 	fs.writeFileSync(join(migrations, '00001-first.js'), 'export async function up() {}\n');
@@ -77,7 +50,7 @@ test('new :: postgres template is JS-compatible with .js extension', async () =>
 });
 
 test('new :: prefers explicit driver over autodetection for template', async () => {
-	const cwd = fs.mkdtempSync(join(tmpBaseDir(), 'ley-new-driver-priority-'));
+	const cwd = fs.mkdtempSync(join(__dirname, '.tmp-ley-new-driver-priority-'));
 	const migrations = join(cwd, 'migrations');
 	fs.mkdirSync(migrations);
 	fs.writeFileSync(join(migrations, '00001-first.js'), 'export async function up() {}\n');

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,10 @@
 const { test } = require('uvu');
 const assert = require('uvu/assert');
+const fs = require('fs');
+const { join } = require('path');
+const os = require('os');
 const ley = require('..');
+const $ = require('../lib/util');
 
 test('exports', () => {
 	assert.type(ley, 'object');
@@ -8,6 +12,49 @@ test('exports', () => {
 	assert.type(ley.down, 'function');
 	assert.type(ley.status, 'function');
 	assert.type(ley.new, 'function');
+});
+
+test('new :: defaults to ESM .ts', async () => {
+	const cwd = fs.mkdtempSync(join(os.tmpdir(), 'ley-new-default-'));
+	const migrations = join(cwd, 'migrations');
+	fs.mkdirSync(migrations);
+	fs.writeFileSync(join(migrations, '00001-first.js'), 'export async function up() {}\n');
+
+	const oldDetect = $.detect;
+	try {
+		$.detect = () => 'pg';
+
+		const output = await ley.new({ cwd, dir: 'migrations', filename: 'users', length: 5, driver: 'pg' });
+		assert.is(output, '00002-users.ts');
+
+		const body = fs.readFileSync(join(migrations, output), 'utf8');
+		assert.is(body, 'export async function up(client) {\n\n}\n\nexport async function down(client) {\n\n}\n');
+	} finally {
+		$.detect = oldDetect;
+	}
+});
+
+test('new :: postgres template uses Sql type', async () => {
+	const cwd = fs.mkdtempSync(join(os.tmpdir(), 'ley-new-postgres-'));
+	const migrations = join(cwd, 'migrations');
+	fs.mkdirSync(migrations);
+	fs.writeFileSync(join(migrations, '00001-first.js'), 'export async function up() {}\n');
+
+	const oldDetect = $.detect;
+	try {
+		$.detect = () => 'postgres';
+
+		const output = await ley.new({ cwd, dir: 'migrations', filename: 'todos', length: 5, driver: 'postgres' });
+		assert.is(output, '00002-todos.ts');
+
+		const body = fs.readFileSync(join(migrations, output), 'utf8');
+		assert.is(
+			body,
+			"import type { Sql } from 'postgres';\n\nexport async function up(sql: Sql) {}\n\nexport async function down(sql: Sql) {}\n"
+		);
+	} finally {
+		$.detect = oldDetect;
+	}
 });
 
 test.run();

--- a/test/index.js
+++ b/test/index.js
@@ -2,7 +2,6 @@ const { test } = require('uvu');
 const assert = require('uvu/assert');
 const fs = require('fs');
 const { join } = require('path');
-const os = require('os');
 const ley = require('..');
 const $ = require('../lib/util');
 
@@ -15,7 +14,7 @@ test('exports', () => {
 });
 
 test('new :: defaults to ESM .ts', async () => {
-	const cwd = fs.mkdtempSync(join(os.tmpdir(), 'ley-new-default-'));
+	const cwd = fs.mkdtempSync(join(__dirname, '.tmp-ley-new-default-'));
 	const migrations = join(cwd, 'migrations');
 	fs.mkdirSync(migrations);
 	fs.writeFileSync(join(migrations, '00001-first.js'), 'export async function up() {}\n');
@@ -31,11 +30,12 @@ test('new :: defaults to ESM .ts', async () => {
 		assert.is(body, 'export async function up(client) {\n\n}\n\nexport async function down(client) {\n\n}\n');
 	} finally {
 		$.detect = oldDetect;
+		fs.rmSync(cwd, { recursive: true, force: true });
 	}
 });
 
 test('new :: postgres template uses Sql type', async () => {
-	const cwd = fs.mkdtempSync(join(os.tmpdir(), 'ley-new-postgres-'));
+	const cwd = fs.mkdtempSync(join(__dirname, '.tmp-ley-new-postgres-'));
 	const migrations = join(cwd, 'migrations');
 	fs.mkdirSync(migrations);
 	fs.writeFileSync(join(migrations, '00001-first.js'), 'export async function up() {}\n');
@@ -54,6 +54,7 @@ test('new :: postgres template uses Sql type', async () => {
 		);
 	} finally {
 		$.detect = oldDetect;
+		fs.rmSync(cwd, { recursive: true, force: true });
 	}
 });
 

--- a/test/index.js
+++ b/test/index.js
@@ -16,7 +16,7 @@ test('new :: postgres template uses Sql type', async () => {
 	const cwd = fs.mkdtempSync(join(__dirname, '.tmp-ley-new-postgres-'));
 	const migrations = join(cwd, 'migrations');
 	fs.mkdirSync(migrations);
-	fs.writeFileSync(join(migrations, '00001-first.js'), 'export async function up() {}\n');
+	fs.writeFileSync(join(migrations, '00001-first.ts'), 'export async function up() {}\n');
 
 	try {
 		const output = await ley.new({ cwd, dir: 'migrations', filename: 'todos', length: 5, driver: 'postgres' });
@@ -32,18 +32,22 @@ test('new :: postgres template uses Sql type', async () => {
 	}
 });
 
-test('new :: postgres template is JS-compatible with .js extension', async () => {
-	const cwd = fs.mkdtempSync(join(__dirname, '.tmp-ley-new-postgres-js-'));
+test('new :: rejects non-TypeScript extension', async () => {
+	const cwd = fs.mkdtempSync(join(__dirname, '.tmp-ley-new-invalid-ext-'));
 	const migrations = join(cwd, 'migrations');
 	fs.mkdirSync(migrations);
-	fs.writeFileSync(join(migrations, '00001-first.js'), 'export async function up() {}\n');
+	fs.writeFileSync(join(migrations, '00001-first.ts'), 'export async function up() {}\n');
 
 	try {
-		const output = await ley.new({ cwd, dir: 'migrations', filename: 'todos.js', length: 5, driver: 'postgres' });
-		assert.is(output, '00002-todos.js');
-
-		const body = fs.readFileSync(join(migrations, output), 'utf8');
-		assert.is(body, 'export async function up(sql) {\n\n}\n\nexport async function down(sql) {\n\n}\n');
+		let caught = false;
+		try {
+			await ley.new({ cwd, dir: 'migrations', filename: 'todos.js', length: 5, driver: 'postgres' });
+			assert.unreachable();
+		} catch (err) {
+			caught = true;
+			assert.match(err.message, /New migration files must use a TypeScript extension/);
+		}
+		assert.ok(caught);
 	} finally {
 		fs.rmSync(cwd, { recursive: true, force: true });
 	}
@@ -53,7 +57,7 @@ test('new :: prefers explicit driver over autodetection for template', async () 
 	const cwd = fs.mkdtempSync(join(__dirname, '.tmp-ley-new-driver-priority-'));
 	const migrations = join(cwd, 'migrations');
 	fs.mkdirSync(migrations);
-	fs.writeFileSync(join(migrations, '00001-first.js'), 'export async function up() {}\n');
+	fs.writeFileSync(join(migrations, '00001-first.ts'), 'export async function up() {}\n');
 	fs.writeFileSync(
 		join(cwd, 'package.json'),
 		JSON.stringify({ name: 'tmp', private: true, dependencies: { postgres: '^3.0.0', pg: '^8.0.0' } }, null, 2)

--- a/test/index.js
+++ b/test/index.js
@@ -1,9 +1,18 @@
 const { test } = require('uvu');
 const assert = require('uvu/assert');
 const fs = require('fs');
-const { join } = require('path');
+const os = require('os');
+const { join, parse, resolve } = require('path');
 const ley = require('..');
-const $ = require('../lib/util');
+
+function tmpBaseDir() {
+	// Windows can place os.tmpdir() on a different drive than the checkout path.
+	// Use OS temp when roots match, otherwise keep temp files in test/ for safety.
+	if (process.platform !== 'win32') return os.tmpdir();
+	const cwdRoot = parse(resolve(process.cwd())).root.toLowerCase();
+	const tmpRoot = parse(resolve(os.tmpdir())).root.toLowerCase();
+	return cwdRoot === tmpRoot ? os.tmpdir() : __dirname;
+}
 
 test('exports', () => {
 	assert.type(ley, 'object');
@@ -14,36 +23,29 @@ test('exports', () => {
 });
 
 test('new :: defaults to ESM .ts', async () => {
-	const cwd = fs.mkdtempSync(join(__dirname, '.tmp-ley-new-default-'));
+	const cwd = fs.mkdtempSync(join(tmpBaseDir(), 'ley-new-default-'));
 	const migrations = join(cwd, 'migrations');
 	fs.mkdirSync(migrations);
 	fs.writeFileSync(join(migrations, '00001-first.js'), 'export async function up() {}\n');
 
-	const oldDetect = $.detect;
 	try {
-		$.detect = () => 'pg';
-
 		const output = await ley.new({ cwd, dir: 'migrations', filename: 'users', length: 5, driver: 'pg' });
 		assert.is(output, '00002-users.ts');
 
 		const body = fs.readFileSync(join(migrations, output), 'utf8');
 		assert.is(body, 'export async function up(client) {\n\n}\n\nexport async function down(client) {\n\n}\n');
 	} finally {
-		$.detect = oldDetect;
 		fs.rmSync(cwd, { recursive: true, force: true });
 	}
 });
 
 test('new :: postgres template uses Sql type', async () => {
-	const cwd = fs.mkdtempSync(join(__dirname, '.tmp-ley-new-postgres-'));
+	const cwd = fs.mkdtempSync(join(tmpBaseDir(), 'ley-new-postgres-'));
 	const migrations = join(cwd, 'migrations');
 	fs.mkdirSync(migrations);
 	fs.writeFileSync(join(migrations, '00001-first.js'), 'export async function up() {}\n');
 
-	const oldDetect = $.detect;
 	try {
-		$.detect = () => 'postgres';
-
 		const output = await ley.new({ cwd, dir: 'migrations', filename: 'todos', length: 5, driver: 'postgres' });
 		assert.is(output, '00002-todos.ts');
 
@@ -53,7 +55,44 @@ test('new :: postgres template uses Sql type', async () => {
 			"import type { Sql } from 'postgres';\n\nexport async function up(sql: Sql) {}\n\nexport async function down(sql: Sql) {}\n"
 		);
 	} finally {
-		$.detect = oldDetect;
+		fs.rmSync(cwd, { recursive: true, force: true });
+	}
+});
+
+test('new :: postgres template is JS-compatible with .js extension', async () => {
+	const cwd = fs.mkdtempSync(join(tmpBaseDir(), 'ley-new-postgres-js-'));
+	const migrations = join(cwd, 'migrations');
+	fs.mkdirSync(migrations);
+	fs.writeFileSync(join(migrations, '00001-first.js'), 'export async function up() {}\n');
+
+	try {
+		const output = await ley.new({ cwd, dir: 'migrations', filename: 'todos.js', length: 5, driver: 'postgres' });
+		assert.is(output, '00002-todos.js');
+
+		const body = fs.readFileSync(join(migrations, output), 'utf8');
+		assert.is(body, 'export async function up(sql) {\n\n}\n\nexport async function down(sql) {\n\n}\n');
+	} finally {
+		fs.rmSync(cwd, { recursive: true, force: true });
+	}
+});
+
+test('new :: prefers explicit driver over autodetection for template', async () => {
+	const cwd = fs.mkdtempSync(join(tmpBaseDir(), 'ley-new-driver-priority-'));
+	const migrations = join(cwd, 'migrations');
+	fs.mkdirSync(migrations);
+	fs.writeFileSync(join(migrations, '00001-first.js'), 'export async function up() {}\n');
+	fs.writeFileSync(
+		join(cwd, 'package.json'),
+		JSON.stringify({ name: 'tmp', private: true, dependencies: { postgres: '^3.0.0', pg: '^8.0.0' } }, null, 2)
+	);
+
+	try {
+		const output = await ley.new({ cwd, dir: 'migrations', filename: 'users', length: 5, driver: 'pg' });
+		assert.is(output, '00002-users.ts');
+
+		const body = fs.readFileSync(join(migrations, output), 'utf8');
+		assert.is(body, 'export async function up(client) {\n\n}\n\nexport async function down(client) {\n\n}\n');
+	} finally {
 		fs.rmSync(cwd, { recursive: true, force: true });
 	}
 });


### PR DESCRIPTION
Closes #4

- [x] Drop `--esm` flag and CommonJS
- [x] Drop non-TypeScript new migration files
- [x] Switch new migrations to use ESM by default
- [x] Switch new migrations to use TypeScript by default
- [x] Switch new migrations to use Postgres.js syntax if detected
- [x] Switch CI matrix to only support Node.js 22 and 24
- [x] Switch CI to `macos-latest`
- [x] Make examples more realistic